### PR TITLE
Preconditioning via override

### DIFF
--- a/src/components/Thermostat/Plan.tsx
+++ b/src/components/Thermostat/Plan.tsx
@@ -19,7 +19,7 @@ function buildOperationPlan(sensorSituations: SensorStatus[], thermostatStatus: 
 
     let why = "";
     if (activeSensor.ruleType === "future") {
-        why = `to prepare for the '${activeSensor.ruleLabel}' rule`;
+        why = `before the next rule starts`;
     } else if (activeSensor.ruleType === "schedule") {
         why = `for the '${activeSensor.ruleLabel}' rule`;
     } else {

--- a/src/components/Thermostat/Sensor.tsx
+++ b/src/components/Thermostat/Sensor.tsx
@@ -21,6 +21,14 @@ function localTime(isoTime: string): string {
     return new Date(isoTime).toLocaleString().split(", ")[1].replace(":00 ", " ");
 }
 
+function getLabel(sensor: SensorStatus): string {
+    if (sensor.ruleType === "override" && sensor.ruleLabel === "Preconditioning") {
+        return "Future";
+    }
+
+    return capitalize(sensor.ruleType);
+}
+
 function getReason(sensor: SensorStatus): string {
     const endType = sensor.ruleType === "future" ? "reach by" : "maintain until";
     let reason = `${endType} ${localTime(sensor.ruleEndsAt)} per rule '${sensor.ruleLabel}'`;
@@ -88,7 +96,7 @@ export default function Sensor({ thermostat, sensor }: SensorProps) {
             />
             <TempBlock
                 temp={ruleTemp}
-                label={capitalize(sensorStatus.ruleType)}
+                label={getLabel(sensorStatus)}
                 onClick={onOverrideClick}
                 tip={getReason(sensorStatus)}
             />

--- a/src/server/event-loop.ts
+++ b/src/server/event-loop.ts
@@ -1,7 +1,7 @@
 import { processSystem } from "./planner";
 import { fetchLastStates, getWeather, setThermostatTemperature } from "./sensors";
 import { getConfig } from "./stores/config";
-import { getOverrides } from "./stores/overrides";
+import { addOverrideForSensor, getOverrides } from "./stores/overrides";
 import { cleanupSystemStates, updateSystemState } from "./stores/system-state";
 import { sleep, temperatureValue } from "./utils";
 
@@ -21,6 +21,10 @@ async function handleSystem(systemConfig: SystemConfig, weatherEntity: string, t
         systemConfig.heating_schedule,
         systemConfig.cooling_schedule,
         await getOverrides(thermostat),
+        async (sensor, temp, until) => {
+            console.log("Precondition requested", sensor, temp, until);
+            await addOverrideForSensor(sensor, until, temp, "Preconditioning");
+        },
         getWeather(weatherEntity) ?? { condition: "sunny", externalTemperature: 70 },
         tz
     );

--- a/src/server/stores/overrides.ts
+++ b/src/server/stores/overrides.ts
@@ -21,10 +21,11 @@ export async function deleteOverride(_thermostat: string, sensor: string): Promi
     await prisma.override.delete({ where: { sensor } });
 }
 
-export async function addOverride(
-    thermostat: string,
-    sensorStatus: SensorStatus,
-    targetTemp: number
+export async function addOverrideForSensor(
+    sensor: string,
+    holdUntil: string,
+    targetTemp: number,
+    reason: string
 ): Promise<Override> {
     if (isNaN(targetTemp) || targetTemp < MIN_TEMP || targetTemp > MAX_TEMP) {
         console.error("Invalid temp");
@@ -32,17 +33,25 @@ export async function addOverride(
     }
 
     const override: Override = {
-        sensor: sensorStatus.id,
+        sensor,
         targetTemp,
-        reason: "User Override",
-        holdUntil: sensorStatus.ruleEndsAt,
+        reason,
+        holdUntil,
     };
 
     await prisma.override.upsert({
-        where: { sensor: sensorStatus.id },
+        where: { sensor },
         update: { ...override },
         create: { ...override },
     });
 
     return override;
+}
+
+export async function addOverride(
+    thermostat: string,
+    sensorStatus: SensorStatus,
+    targetTemp: number
+): Promise<Override> {
+    return addOverrideForSensor(sensorStatus.id, sensorStatus.ruleEndsAt, targetTemp, "User Override");
 }


### PR DESCRIPTION
Once preconditioning is required for the first time during a rule, create an override to persist the preconditioning status.  This way the thermostat won't flip flop as the temp drops.